### PR TITLE
Fix link to conversation using a relative path

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ I drew from these sources:
 2. [Systutorials](https://www.systutorials.com/docs/linux/man/1-pulseaudio/#lbAI)
 3. [Archlinux](https://wiki.archlinux.org/index.php/PulseAudio/Troubleshooting)
 4. [Linux Mint Forums](https://forums.linuxmint.com/viewtopic.php?t=253225)
-5. Personal [communication](https://github.com/andres-jurado/audiophile-linux/blob/tanu-kaskinen/other/Tanu%20Kaskinen/conversation.md) with pulseaudio developer Tanu Kaskinen
+5. Personal [communication](./other/Tanu%20Kaskinen/conversation.md) with pulseaudio developer Tanu Kaskinen
 
 Note that `resample-method = speex-float-10` might be [overkill](https://pulseaudio-discuss.freedesktop.narkive.com/KVOBRkZO/patch-2-4-enabled-libsoxr-resampler-backend#post5).
 


### PR DESCRIPTION
The old link was broken, and to prevent future breackages, we can use a relative path.

You can check that it is working by clicking on the link on the branch in which I made the change:
- https://github.com/ibLeDy/audiophile-linux/tree/fix/link-to-conversation

We could also use [a permalink](https://github.com/andres-jurado/audiophile-linux/blob/ce63e5c3011971b498573f514647ec7ba325c13c/other/Tanu%20Kaskinen/conversation.md), since the document is not supposed to change, but if the link is used only on GitHub we don't need to, as with the relative path GitHub will always convert the path to the appropiate url